### PR TITLE
Implement Reward Locker for Liquidity Mining program

### DIFF
--- a/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
+++ b/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
@@ -5,6 +5,12 @@ pragma abicoder v2;
 import {IERC20Ext} from '@kyber.network/utils-sc/contracts/IERC20Ext.sol';
 
 interface IKyberRewardLocker {
+  struct VestingSchedule {
+    uint64 startTime;
+    uint64 endTime;
+    uint128 quantity;
+  }
+
   event VestingEntryCreated(
     IERC20Ext indexed token,
     address indexed beneficiary,
@@ -20,16 +26,64 @@ interface IKyberRewardLocker {
     uint256 slashedQuantity
   );
 
+  /**
+   * @dev queue a vesting schedule starting from now
+   */
   function lock(
     IERC20Ext token,
     address account,
     uint256 amount
   ) external;
 
+  /**
+   * @dev queue a vesting schedule
+   */
   function lockWithStartTime(
     IERC20Ext token,
     address account,
     uint256 quantity,
     uint256 startTime
   ) external;
+
+  /**
+   * @dev for all completed schedule, claim token
+   */
+  function vestCompletedSchedules(IERC20Ext token) external returns (uint256);
+
+  /**
+   * @dev claim token for specific vesting schedule,
+   * @dev if schedule has not ended yet, claiming amount is linear with vesting time (the rest are slashing)
+   */
+  function vestScheduleAtIndex(IERC20Ext token, uint256[] calldata indexes)
+    external
+    returns (uint256);
+
+  /**
+   * @dev length of vesting schedules array
+   */
+  function numVestingSchedules(address account, IERC20Ext token) external view returns (uint256);
+
+  /**
+   * @dev get detailed of each vesting schedule
+   */
+  function getVestingScheduleAtIndex(
+    address account,
+    IERC20Ext token,
+    uint256 index
+  )
+    external
+    view
+    returns (
+      uint64 startTime,
+      uint64 endTime,
+      uint128 quantity
+    );
+
+  /**
+   * @dev get vesting shedules array
+   */
+  function getVestingSchedules(address account, IERC20Ext token)
+    external
+    view
+    returns (VestingSchedule[] memory schedules);
 }

--- a/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
+++ b/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
@@ -4,7 +4,32 @@ pragma abicoder v2;
 
 import {IERC20Ext} from '@kyber.network/utils-sc/contracts/IERC20Ext.sol';
 
-
 interface IKyberRewardLocker {
-  function lock(IERC20Ext token, address account, uint256 amount) external;
+  event VestingEntryCreated(
+    IERC20Ext indexed token,
+    address indexed beneficiary,
+    uint256 time,
+    uint256 value
+  );
+
+  event Vested(
+    IERC20Ext indexed token,
+    address indexed beneficiary,
+    uint256 time,
+    uint256 vestedQuantity,
+    uint256 slashedQuantity
+  );
+
+  function lock(
+    IERC20Ext token,
+    address account,
+    uint256 amount
+  ) external;
+
+  function lockWithStartTime(
+    IERC20Ext token,
+    address account,
+    uint256 quantity,
+    uint256 startTime
+  ) external;
 }

--- a/contracts/liquidityMining/KyberRewardLocker.sol
+++ b/contracts/liquidityMining/KyberRewardLocker.sol
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.6;
+pragma abicoder v2;
+
+import {IERC20Ext} from '@kyber.network/utils-sc/contracts/IERC20Ext.sol';
+import {SafeMath} from '@openzeppelin/contracts/math/SafeMath.sol';
+import {SafeCast} from '@openzeppelin/contracts/utils/SafeCast.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/SafeERC20.sol';
+import {EnumerableSet} from '@openzeppelin/contracts/utils/EnumerableSet.sol';
+import {PermissionAdmin} from '@kyber.network/utils-sc/contracts/PermissionAdmin.sol';
+
+import {IKyberRewardLocker} from '../interfaces/liquidityMining/IKyberRewardLocker.sol';
+
+interface IERC20Burnable {
+  function burn(uint256 _value) external;
+}
+
+contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
+  using SafeMath for uint256;
+  using SafeCast for uint256;
+
+  using SafeERC20 for IERC20Ext;
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  struct VestingSchedule {
+    uint64 startTime;
+    uint64 endTime;
+    uint128 quantity;
+  }
+
+  struct VestingSchedules {
+    uint256 length;
+    mapping(uint256 => VestingSchedule) data;
+  }
+
+  uint256 private constant MAX_REWARD_CONTRACTS_SIZE = 10;
+
+  /// @dev whitelist of reward contracts
+  mapping(IERC20Ext => EnumerableSet.AddressSet) internal rewardContractsPerToken;
+
+  /// @dev vesting schedule of an account
+  mapping(address => mapping(IERC20Ext => VestingSchedules)) private accountsVestingSchedules;
+
+  /// @dev An account's total escrowed balance per token to save recomputing this for fee extraction purposes
+  mapping(address => mapping(IERC20Ext => uint256)) public accountEscrowedBalance;
+
+  /// @dev An account's total vested reward per token
+  mapping(address => mapping(IERC20Ext => uint256)) public accountVestedBalance;
+
+  /// @dev where slashing tokens goes
+  mapping(IERC20Ext => address) public slashingTargets;
+
+  /// @dev lock time
+  mapping(IERC20Ext => uint256) public lockTime;
+
+  /* ========== EVENTS ========== */
+  event RewardContractAdded(address indexed rewardContract, bool isAdded);
+  event SetSlashingTarget(IERC20Ext indexed token, address target);
+  event SetLockTime(IERC20Ext indexed token, uint256 _lockTime);
+
+  /* ========== MODIFIERS ========== */
+
+  modifier onlyRewardsContract(IERC20Ext token) {
+    require(rewardContractsPerToken[token].contains(msg.sender), 'onlyRewardcontract');
+    _;
+  }
+
+  constructor(address _admin) PermissionAdmin(_admin) {}
+
+  /**
+   * @notice Add a whitelisted rewards contract
+   */
+  function addRewardsContract(IERC20Ext token, address _rewardContract) external onlyAdmin {
+    require(
+      rewardContractsPerToken[token].length() < MAX_REWARD_CONTRACTS_SIZE,
+      'rewardContracts is too long'
+    );
+    require(rewardContractsPerToken[token].add(_rewardContract), '_rewardContract is added');
+
+    emit RewardContractAdded(_rewardContract, true);
+  }
+
+  /**
+   * @notice Remove a whitelisted rewards contract
+   */
+  function removeRewardsContract(IERC20Ext token, address _rewardContract) external onlyAdmin {
+    require(rewardContractsPerToken[token].remove(_rewardContract), '_rewardContract is removed');
+
+    emit RewardContractAdded(_rewardContract, false);
+  }
+
+  function setSlashingTarget(IERC20Ext token, address target) external onlyAdmin {
+    slashingTargets[token] = target;
+
+    emit SetSlashingTarget(token, target);
+  }
+
+  function setLockTime(IERC20Ext token, uint256 _lockTime) external onlyAdmin {
+    lockTime[token] = _lockTime;
+
+    emit SetLockTime(token, _lockTime);
+  }
+
+  function lock(
+    IERC20Ext token,
+    address account,
+    uint256 quantity
+  ) external override {
+    lockWithStartTime(token, account, quantity, _blockTimestamp());
+  }
+
+  function lockWithStartTime(
+    IERC20Ext token,
+    address account,
+    uint256 quantity,
+    uint256 startTime
+  ) public override onlyRewardsContract(token) {
+    require(quantity != 0, 'Quantity cannot be zero');
+
+    // transfer token from reward contract to lock contract
+    token.safeTransferFrom(msg.sender, address(this), quantity);
+
+    VestingSchedules storage schedules = accountsVestingSchedules[account][token];
+    uint256 schedulesLength = schedules.length;
+
+    uint256 endTime = startTime.add(lockTime[token]);
+
+    if (schedulesLength == 0) {
+      accountEscrowedBalance[account][token] = quantity;
+    } else {
+      /* Disallow adding new vested XTK earlier than the last one. */
+      require(schedules.data[schedulesLength - 1].endTime < endTime, 'not linear vesting');
+      accountEscrowedBalance[account][token] = accountEscrowedBalance[account][token].add(
+        quantity
+      );
+    }
+    // append to storage, the schedule data
+    schedules.data[schedulesLength] = VestingSchedule({
+      startTime: startTime.toUint64(),
+      endTime: endTime.toUint64(),
+      quantity: quantity.toUint128()
+    });
+    schedules.length = schedulesLength + 1;
+
+    emit VestingEntryCreated(token, account, _blockTimestamp(), quantity);
+  }
+
+  /**
+   * @notice Allow a user to withdraw any XTK in their schedule that have vested.
+   */
+  function vestAll(IERC20Ext token) external returns (uint256) {
+    VestingSchedules storage schedules = accountsVestingSchedules[msg.sender][token];
+    uint256 schedulesLength = schedules.length;
+
+    uint256 totalVesting = 0;
+    uint256 totalSlashing = 0;
+    for (uint256 i = 0; i < schedulesLength; i++) {
+      VestingSchedule memory schedule = schedules.data[i];
+      if (schedule.quantity == 0) {
+        continue;
+      }
+      uint256 vestQuantity = _getVestingQuantity(
+        schedule.quantity,
+        schedule.startTime,
+        schedule.endTime
+      );
+      totalVesting = totalVesting.add(vestQuantity);
+      totalSlashing = totalSlashing.add(schedule.quantity - vestQuantity);
+      // clear data after vesting
+      schedules.data[i].quantity = 0;
+    }
+    require(totalVesting != 0, 'invalid vesting amount');
+    accountEscrowedBalance[msg.sender][token] = accountEscrowedBalance[msg.sender][token].sub(
+      totalVesting.add(totalSlashing)
+    );
+    accountVestedBalance[msg.sender][token] = accountVestedBalance[msg.sender][token].add(
+      totalVesting
+    );
+
+    token.safeTransfer(msg.sender, totalVesting);
+    if (totalSlashing != 0) _slash(token, totalSlashing);
+
+    emit Vested(token, msg.sender, _blockTimestamp(), totalVesting, totalSlashing);
+
+    return totalVesting;
+  }
+
+  function vestAtIndex(IERC20Ext token, uint256[] calldata indexes) external returns (uint256) {
+    VestingSchedules storage schedules = accountsVestingSchedules[msg.sender][token];
+    uint256 totalVesting = 0;
+    uint256 totalSlashing = 0;
+    for (uint256 i = 0; i < indexes.length; i++) {
+      VestingSchedule memory schedule = schedules.data[indexes[i]];
+      if (schedule.quantity == 0) {
+        continue;
+      }
+      uint256 vestQuantity = _getVestingQuantity(
+        schedule.quantity,
+        schedule.startTime,
+        schedule.endTime
+      );
+      totalVesting = totalVesting.add(vestQuantity);
+      totalSlashing = totalSlashing.add(schedule.quantity - vestQuantity);
+      // clear data after vesting
+      schedules.data[i].quantity = 0;
+    }
+    require(totalVesting != 0, 'invalid vesting amount');
+
+    accountEscrowedBalance[msg.sender][token] = accountEscrowedBalance[msg.sender][token].sub(
+      totalVesting.add(totalSlashing)
+    );
+    accountVestedBalance[msg.sender][token] = accountVestedBalance[msg.sender][token].add(
+      totalVesting
+    );
+
+    token.safeTransfer(msg.sender, totalVesting);
+    if (totalSlashing != 0) _slash(token, totalSlashing);
+
+    emit Vested(token, msg.sender, _blockTimestamp(), totalVesting, totalSlashing);
+
+    return totalVesting;
+  }
+
+  /* ========== VIEW FUNCTIONS ========== */
+
+  /**
+   * @notice The number of vesting dates in an account's schedule.
+   */
+  function numVestingSchedules(address account, IERC20Ext token) external view returns (uint256) {
+    return accountsVestingSchedules[account][token].length;
+  }
+
+  /**
+   * @dev manually get vesting schedule at index
+   */
+  function getVestingScheduleAtIndex(
+    address account,
+    IERC20Ext token,
+    uint256 index
+  )
+    external
+    view
+    returns (
+      uint64 startTime,
+      uint64 endTime,
+      uint128 quantity
+    )
+  {
+    VestingSchedule memory schedule = accountsVestingSchedules[account][token].data[index];
+    return (schedule.startTime, schedule.endTime, schedule.quantity);
+  }
+
+  /**
+   * @dev Get all schedules for an account.
+   */
+  function getVestingSchedules(address account, IERC20Ext token)
+    external
+    view
+    returns (VestingSchedule[] memory schedules)
+  {
+    uint256 schedulesLength = accountsVestingSchedules[account][token].length;
+    schedules = new VestingSchedule[](schedulesLength);
+    for (uint256 i = 0; i < schedulesLength; i++) {
+      schedules[i] = accountsVestingSchedules[account][token].data[i];
+    }
+  }
+
+  function getRewardContractsPerToken(IERC20Ext token)
+    external
+    view
+    returns (address[] memory rewardContracts)
+  {
+    rewardContracts = new address[](rewardContractsPerToken[token].length());
+    for (uint256 i = 0; i < rewardContracts.length; i++) {
+      rewardContracts[i] = rewardContractsPerToken[token].at(i);
+    }
+  }
+
+  /* ========== INTERNAL FUNCTIONS ========== */
+
+  /**
+   * @dev if slashingTarget is equals to 0 address, burn the reward else transfer to the target
+   */
+  function _slash(IERC20Ext token, uint256 amount) internal {
+    address target = slashingTargets[token];
+    if (target != address(0)) {
+      token.safeTransfer(target, amount);
+    } else {
+      IERC20Burnable(address(token)).burn(amount);
+    }
+  }
+
+  /**
+   * @dev implements slashing mechanism
+   * @dev this will allow user to claim token early, but slash the rest of token.
+   */
+  function _getVestingQuantity(
+    uint256 quantity,
+    uint256 startTime,
+    uint256 endTime
+  ) internal view returns (uint256) {
+    if (_blockTimestamp() >= endTime) {
+      return quantity;
+    }
+    if (_blockTimestamp() <= startTime) {
+      return 0;
+    }
+    return _blockTimestamp().sub(startTime).mul(quantity).div(endTime - startTime);
+  }
+
+  /**
+   * @dev wrap timestamp so we can easily mock it
+   */
+  function _blockTimestamp() internal virtual view returns (uint256) {
+    return block.timestamp;
+  }
+}

--- a/contracts/mock/liquidityMining/MockRewardLocker.sol
+++ b/contracts/mock/liquidityMining/MockRewardLocker.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.6;
+pragma abicoder v2;
+
+import {KyberRewardLocker} from '../../liquidityMining/KyberRewardLocker.sol';
+
+contract MockRewardLocker is KyberRewardLocker {
+  uint256 internal timestamp;
+
+  constructor(address _admin) KyberRewardLocker(_admin) {}
+
+  function setTimestamp(uint256 _timestamp) external {
+    timestamp = _timestamp;
+  }
+
+  function _blockTimestamp() internal override view returns (uint256) {
+    return timestamp;
+  }
+}

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -68,8 +68,8 @@ contract('KyberRewardLocker', (accounts) => {
       );
 
       txResult = await rewardLocker.setVestingConfig(rewardToken.address, new BN(1000), new BN(10), {from: admin});
-      expectEvent(txResult, 'SetVestingConfig', {lockTime: new BN(1000)});
-      Helper.assertEqual((await rewardLocker.vestingConfigPerToken(rewardToken.address)).lockTime, new BN(1000));
+      expectEvent(txResult, 'SetVestingConfig', {lockDuration: new BN(1000)});
+      Helper.assertEqual((await rewardLocker.vestingConfigPerToken(rewardToken.address)).lockDuration, new BN(1000));
     });
 
     it('set slashing target', async () => {
@@ -108,7 +108,7 @@ contract('KyberRewardLocker', (accounts) => {
 
       await rewardLocker.setTimestamp(new BN(10800));
 
-      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      txResult = await rewardLocker.vestCompletedSchedules(rewardToken.address, {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
@@ -131,7 +131,7 @@ contract('KyberRewardLocker', (accounts) => {
 
       await rewardLocker.setTimestamp(new BN(9000));
 
-      txResult = await rewardLocker.vestAtIndex(rewardToken.address, [new BN(0)], {from: user1});
+      txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
@@ -159,7 +159,7 @@ contract('KyberRewardLocker', (accounts) => {
 
       await rewardLocker.setTimestamp(new BN(9000));
 
-      txResult = await rewardLocker.vestAtIndex(rewardToken.address, [new BN(0)], {from: user1});
+      txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -61,12 +61,15 @@ contract('KyberRewardLocker', (accounts) => {
       Helper.assertEqual(await rewardLocker.getRewardContractsPerToken(rewardToken.address), [rewardContract]);
     });
 
-    it('set lock time', async () => {
-      await expectRevert(rewardLocker.setLockTime(rewardToken.address, new BN(1000), {from: user1}), 'only admin');
+    it('set vesting config', async () => {
+      await expectRevert(
+        rewardLocker.setVestingConfig(rewardToken.address, new BN(1000), new BN(10), {from: user1}),
+        'only admin'
+      );
 
-      txResult = await rewardLocker.setLockTime(rewardToken.address, new BN(1000), {from: admin});
-      expectEvent(txResult, 'SetLockTime', {_lockTime: new BN(1000)});
-      Helper.assertEqual(await rewardLocker.lockTime(rewardToken.address), new BN(1000));
+      txResult = await rewardLocker.setVestingConfig(rewardToken.address, new BN(1000), new BN(10), {from: admin});
+      expectEvent(txResult, 'SetVestingConfig', {lockTime: new BN(1000)});
+      Helper.assertEqual((await rewardLocker.vestingConfigPerToken(rewardToken.address)).lockTime, new BN(1000));
     });
 
     it('set slashing target', async () => {
@@ -85,7 +88,7 @@ contract('KyberRewardLocker', (accounts) => {
     beforeEach('setup', async () => {
       rewardLocker = await RewardLocker.new(admin);
       await rewardLocker.addRewardsContract(rewardToken.address, rewardContract, {from: admin});
-      await rewardLocker.setLockTime(rewardToken.address, new BN(3600), {from: admin});
+      await rewardLocker.setVestingConfig(rewardToken.address, new BN(3600), new BN(60), {from: admin});
     });
 
     it('lock and vest with full time', async () => {

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -1,0 +1,174 @@
+const {artifacts} = require('hardhat');
+const {expectRevert} = require('@openzeppelin/test-helpers');
+const Helper = require('../helper.js');
+const expectEvent = require('@openzeppelin/test-helpers/src/expectEvent');
+const {expect} = require('chai');
+const BN = web3.utils.BN;
+
+const RewardLocker = artifacts.require('MockRewardLocker');
+const KNC = artifacts.require('KyberNetworkTokenV2');
+
+let admin;
+let user1;
+let user2;
+let rewardLocker;
+let rewardContract;
+let rewardContract2;
+let rewardToken;
+let slashingTarget;
+
+let txResult;
+
+contract('KyberRewardLocker', (accounts) => {
+  before('setup', async () => {
+    admin = accounts[1];
+
+    user1 = accounts[2];
+    user2 = accounts[3];
+    rewardContract = accounts[4];
+    rewardContract2 = accounts[5];
+    slashingTarget = accounts[6];
+
+    rewardToken = await KNC.new();
+  });
+  describe('admin operations', async () => {
+    beforeEach('init rewardLocker', async () => {
+      rewardLocker = await RewardLocker.new(admin);
+    });
+
+    it('add/remove reward contract', async () => {
+      await expectRevert(
+        rewardLocker.addRewardsContract(rewardToken.address, rewardContract, {from: user1}),
+        'only admin'
+      );
+      txResult = await rewardLocker.addRewardsContract(rewardToken.address, rewardContract, {from: admin});
+
+      expectEvent(txResult, 'RewardContractAdded', {isAdded: true, rewardContract: rewardContract});
+      await rewardLocker.addRewardsContract(rewardToken.address, rewardContract2, {from: admin});
+
+      Helper.assertEqual(await rewardLocker.getRewardContractsPerToken(rewardToken.address), [
+        rewardContract,
+        rewardContract2,
+      ]);
+
+      await expectRevert(
+        rewardLocker.removeRewardsContract(rewardToken.address, rewardContract2, {from: user1}),
+        'only admin'
+      );
+      txResult = await rewardLocker.removeRewardsContract(rewardToken.address, rewardContract2, {from: admin});
+      expectEvent(txResult, 'RewardContractAdded', {isAdded: false, rewardContract: rewardContract2});
+
+      Helper.assertEqual(await rewardLocker.getRewardContractsPerToken(rewardToken.address), [rewardContract]);
+    });
+
+    it('set lock time', async () => {
+      await expectRevert(rewardLocker.setLockTime(rewardToken.address, new BN(1000), {from: user1}), 'only admin');
+
+      txResult = await rewardLocker.setLockTime(rewardToken.address, new BN(1000), {from: admin});
+      expectEvent(txResult, 'SetLockTime', {_lockTime: new BN(1000)});
+      Helper.assertEqual(await rewardLocker.lockTime(rewardToken.address), new BN(1000));
+    });
+
+    it('set slashing target', async () => {
+      await expectRevert(
+        rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: user1}),
+        'only admin'
+      );
+
+      txResult = await rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: admin});
+      expectEvent(txResult, 'SetSlashingTarget', {target: slashingTarget});
+      expect(await rewardLocker.slashingTargets(rewardToken.address)).equal(slashingTarget);
+    });
+  });
+
+  describe('lock and vest', async () => {
+    beforeEach('setup', async () => {
+      rewardLocker = await RewardLocker.new(admin);
+      await rewardLocker.addRewardsContract(rewardToken.address, rewardContract, {from: admin});
+      await rewardLocker.setLockTime(rewardToken.address, new BN(3600), {from: admin});
+    });
+
+    it('lock and vest with full time', async () => {
+      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
+      await rewardToken.transfer(rewardContract, vestingQuantity);
+      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
+
+      await rewardLocker.setTimestamp(new BN(7200));
+
+      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+
+      let vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
+      expect(vestingSchedules.length).equals(1);
+      Helper.assertEqual(vestingSchedules[0].startTime, new BN(7200));
+      Helper.assertEqual(vestingSchedules[0].endTime, new BN(10800));
+      Helper.assertEqual(vestingSchedules[0].quantity, vestingQuantity);
+
+      await rewardLocker.setTimestamp(new BN(10800));
+
+      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        time: new BN(10800),
+        vestedQuantity: vestingQuantity,
+        slashedQuantity: new BN(0),
+      });
+    });
+
+    it('lock and vest and burn with half time', async () => {
+      await rewardLocker.setSlashingTarget(rewardToken.address, Helper.zeroAddress, {from: admin});
+
+      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
+      await rewardToken.transfer(rewardContract, vestingQuantity);
+      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
+
+      await rewardLocker.setTimestamp(new BN(7200));
+
+      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+
+      await rewardLocker.setTimestamp(new BN(9000));
+
+      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        time: new BN(9000),
+        vestedQuantity: vestingQuantity.div(new BN(2)),
+        slashedQuantity: vestingQuantity.div(new BN(2)),
+      });
+
+      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
+        to: Helper.zeroAddress,
+        value: vestingQuantity.div(new BN(2)),
+      });
+    });
+
+    it('lock and vest and transfer slashing quantity with half time', async () => {
+      await rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: admin});
+
+      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
+      await rewardToken.transfer(rewardContract, vestingQuantity);
+      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
+
+      await rewardLocker.setTimestamp(new BN(7200));
+
+      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+
+      await rewardLocker.setTimestamp(new BN(9000));
+
+      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        time: new BN(9000),
+        vestedQuantity: vestingQuantity.div(new BN(2)),
+        slashedQuantity: vestingQuantity.div(new BN(2)),
+      });
+
+      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
+        to: slashingTarget,
+        value: vestingQuantity.div(new BN(2)),
+      });
+    });
+  });
+});

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -131,7 +131,7 @@ contract('KyberRewardLocker', (accounts) => {
 
       await rewardLocker.setTimestamp(new BN(9000));
 
-      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      txResult = await rewardLocker.vestAtIndex(rewardToken.address, [new BN(0)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
@@ -159,7 +159,7 @@ contract('KyberRewardLocker', (accounts) => {
 
       await rewardLocker.setTimestamp(new BN(9000));
 
-      txResult = await rewardLocker.vestAll(rewardToken.address, {from: user1});
+      txResult = await rewardLocker.vestAtIndex(rewardToken.address, [new BN(0)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,


### PR DESCRIPTION
Original source from xtk:
https://etherscan.io/address/0xa2ecc4ad68f2ddd5fcd43a23280c8e34a54c1c27#code
Change from xtk locking mechanism
- allows user to redeem early with slashing
  - if slashing target is zero, burn the token
  - if slashing target is not zero, transfer slashing data to it
- has configuration for locking time
   - hence vesting schedule array is not in increasing order of ending time.  allow user to vest with specific index  
   - if the last schedule start time is not far from current time and locktime of last schedule is equals to current locktime, merge them into 1 schedule.
- allows multiple reward contracts