### PR TITLE
Switch locking mechanism to just linearly vesting over blocks

### DIFF
--- a/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
+++ b/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
@@ -6,24 +6,23 @@ import {IERC20Ext} from '@kyber.network/utils-sc/contracts/IERC20Ext.sol';
 
 interface IKyberRewardLocker {
   struct VestingSchedule {
-    uint64 startTime;
-    uint64 endTime;
+    uint64 startBlock;
+    uint64 endBlock;
     uint128 quantity;
   }
 
   event VestingEntryCreated(
     IERC20Ext indexed token,
     address indexed beneficiary,
-    uint256 time,
+    uint256 blockNumber,
     uint256 value
   );
 
   event Vested(
     IERC20Ext indexed token,
     address indexed beneficiary,
-    uint256 time,
-    uint256 vestedQuantity,
-    uint256 slashedQuantity
+    uint256 blockNumber,
+    uint256 vestedQuantity
   );
 
   /**
@@ -38,11 +37,11 @@ interface IKyberRewardLocker {
   /**
    * @dev queue a vesting schedule
    */
-  function lockWithStartTime(
+  function lockWithStartBlock(
     IERC20Ext token,
     address account,
     uint256 quantity,
-    uint256 startTime
+    uint256 startBlock
   ) external;
 
   /**
@@ -52,7 +51,7 @@ interface IKyberRewardLocker {
 
   /**
    * @dev claim token for specific vesting schedule,
-   * @dev if schedule has not ended yet, claiming amount is linear with vesting time (the rest are slashing)
+   * @dev if schedule has not ended yet, claiming amount is linear with vesting blocks
    */
   function vestScheduleAtIndex(IERC20Ext token, uint256[] calldata indexes)
     external
@@ -74,8 +73,8 @@ interface IKyberRewardLocker {
     external
     view
     returns (
-      uint64 startTime,
-      uint64 endTime,
+      uint64 startBlock,
+      uint64 endBlock,
       uint128 quantity
     );
 

--- a/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
+++ b/contracts/interfaces/liquidityMining/IKyberRewardLocker.sol
@@ -9,20 +9,23 @@ interface IKyberRewardLocker {
     uint64 startBlock;
     uint64 endBlock;
     uint128 quantity;
+    uint128 vestedQuantity;
   }
 
   event VestingEntryCreated(
     IERC20Ext indexed token,
     address indexed beneficiary,
-    uint256 blockNumber,
-    uint256 value
+    uint256 startBlock,
+    uint256 endBlock,
+    uint256 quantity,
+    uint256 index
   );
 
   event Vested(
     IERC20Ext indexed token,
     address indexed beneficiary,
-    uint256 blockNumber,
-    uint256 vestedQuantity
+    uint256 vestedQuantity,
+    uint256 index
   );
 
   /**
@@ -58,6 +61,15 @@ interface IKyberRewardLocker {
     returns (uint256);
 
   /**
+   * @dev claim token for specific vesting schedule from startIndex to endIndex
+   */
+  function vestSchedulesInRange(
+    IERC20Ext token,
+    uint256 startIndex,
+    uint256 endIndex
+  ) external returns (uint256);
+
+  /**
    * @dev length of vesting schedules array
    */
   function numVestingSchedules(address account, IERC20Ext token) external view returns (uint256);
@@ -69,14 +81,7 @@ interface IKyberRewardLocker {
     address account,
     IERC20Ext token,
     uint256 index
-  )
-    external
-    view
-    returns (
-      uint64 startBlock,
-      uint64 endBlock,
-      uint128 quantity
-    );
+  ) external view returns (VestingSchedule memory);
 
   /**
    * @dev get vesting shedules array

--- a/contracts/liquidityMining/KyberRewardLocker.sol
+++ b/contracts/liquidityMining/KyberRewardLocker.sol
@@ -30,7 +30,7 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
 
   struct VestingConfig {
     uint64 lockDuration;
-    uint64 negligibleTimeDifference;
+    uint64 negligibleBlockDifference;
   }
 
   uint256 private constant MAX_REWARD_CONTRACTS_SIZE = 10;
@@ -47,19 +47,15 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
   /// @dev An account's total vested reward per token
   mapping(address => mapping(IERC20Ext => uint256)) public accountVestedBalance;
 
-  /// @dev where slashing tokens goes
-  mapping(IERC20Ext => address) public slashingTargets;
-
-  /// @dev lock time
+  /// @dev lock config
   mapping(IERC20Ext => VestingConfig) public vestingConfigPerToken;
 
   /* ========== EVENTS ========== */
   event RewardContractAdded(address indexed rewardContract, bool isAdded);
-  event SetSlashingTarget(IERC20Ext indexed token, address target);
   event SetVestingConfig(
     IERC20Ext indexed token,
     uint64 lockDuration,
-    uint64 negligibleTimeDifference
+    uint64 negligibleBlockDifference
   );
 
   /* ========== MODIFIERS ========== */
@@ -93,23 +89,17 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
     emit RewardContractAdded(_rewardContract, false);
   }
 
-  function setSlashingTarget(IERC20Ext token, address target) external onlyAdmin {
-    slashingTargets[token] = target;
-
-    emit SetSlashingTarget(token, target);
-  }
-
   function setVestingConfig(
     IERC20Ext token,
     uint64 _lockDuration,
-    uint64 _negligibleTimeDifference
+    uint64 _negligibleBlockDifference
   ) external onlyAdmin {
     vestingConfigPerToken[token] = VestingConfig({
       lockDuration: _lockDuration,
-      negligibleTimeDifference: _negligibleTimeDifference
+      negligibleBlockDifference: _negligibleBlockDifference
     });
 
-    emit SetVestingConfig(token, _lockDuration, _negligibleTimeDifference);
+    emit SetVestingConfig(token, _lockDuration, _negligibleBlockDifference);
   }
 
   function lock(
@@ -117,14 +107,14 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
     address account,
     uint256 quantity
   ) external override {
-    lockWithStartTime(token, account, quantity, _blockTimestamp());
+    lockWithStartBlock(token, account, quantity, _blockNumber());
   }
 
-  function lockWithStartTime(
+  function lockWithStartBlock(
     IERC20Ext token,
     address account,
     uint256 quantity,
-    uint256 startTime
+    uint256 startBlock
   ) public override onlyRewardsContract(token) {
     require(quantity > 0, 'Quantity cannot be zero');
 
@@ -135,36 +125,36 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
     uint256 schedulesLength = schedules.length;
 
     VestingConfig memory config = vestingConfigPerToken[token];
-    uint256 endTime = startTime.add(config.lockDuration);
+    uint256 endBlock = startBlock.add(config.lockDuration);
 
     if (schedulesLength == 0) {
       accountEscrowedBalance[account][token] = quantity;
       schedules.data[0] = VestingSchedule({
-        startTime: startTime.toUint64(),
-        endTime: endTime.toUint64(),
+        startBlock: startBlock.toUint64(),
+        endBlock: endBlock.toUint64(),
         quantity: quantity.toUint128()
       });
       schedules.length = 1;
     } else {
       VestingSchedule memory lastSchedule = schedules.data[schedulesLength - 1];
-      uint256 lastLockDuration = uint256(lastSchedule.endTime).sub(lastSchedule.startTime);
+      uint256 lastLockDuration = uint256(lastSchedule.endBlock).sub(lastSchedule.startBlock);
       ///  if lockDuration of lastSchedule == current lockDuration
-      /// and the diffrent between startTime of lastSchedule and startTime are negligible
+      /// and the diffrent between startBlock of lastSchedule and startBlock are negligible
       /// then merge schedule
       if (
-        lastSchedule.startTime > startTime.sub(config.negligibleTimeDifference) &&
+        lastSchedule.startBlock > startBlock.sub(config.negligibleBlockDifference) &&
         lastLockDuration == config.lockDuration
       ) {
         schedules.data[schedulesLength - 1] = VestingSchedule({
-          startTime: startTime.toUint64(),
-          endTime: endTime.toUint64(),
+          startBlock: startBlock.toUint64(),
+          endBlock: endBlock.toUint64(),
           quantity: uint256(lastSchedule.quantity).add(quantity).toUint128()
         });
       } else {
         // append to storage, the schedule data
         schedules.data[schedulesLength] = VestingSchedule({
-          startTime: startTime.toUint64(),
-          endTime: endTime.toUint64(),
+          startBlock: startBlock.toUint64(),
+          endBlock: endBlock.toUint64(),
           quantity: quantity.toUint128()
         });
         schedules.length = schedulesLength + 1;
@@ -174,7 +164,7 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
       );
     }
 
-    emit VestingEntryCreated(token, account, _blockTimestamp(), quantity);
+    emit VestingEntryCreated(token, account, _blockNumber(), quantity);
   }
 
   /**
@@ -190,7 +180,7 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
       if (schedule.quantity == 0) {
         continue;
       }
-      if (_blockTimestamp() < schedule.endTime) {
+      if (_blockNumber() < schedule.endBlock) {
         continue;
       }
       totalVesting = totalVesting.add(schedule.quantity);
@@ -207,7 +197,7 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
 
     token.safeTransfer(msg.sender, totalVesting);
 
-    emit Vested(token, msg.sender, _blockTimestamp(), totalVesting, 0);
+    emit Vested(token, msg.sender, _blockNumber(), totalVesting);
     return totalVesting;
   }
 
@@ -221,7 +211,6 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
   {
     VestingSchedules storage schedules = accountVestingSchedules[msg.sender][token];
     uint256 totalVesting = 0;
-    uint256 totalSlashing = 0;
     for (uint256 i = 0; i < indexes.length; i++) {
       VestingSchedule memory schedule = schedules.data[indexes[i]];
       if (schedule.quantity == 0) {
@@ -229,30 +218,36 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
       }
       uint256 vestQuantity = _getVestingQuantity(
         schedule.quantity,
-        schedule.startTime,
-        schedule.endTime
+        schedule.startBlock,
+        schedule.endBlock
       );
       if (vestQuantity == 0) {
         continue;
       }
       totalVesting = totalVesting.add(vestQuantity);
-      totalSlashing = totalSlashing.add(schedule.quantity - vestQuantity);
-      // clear data after vesting
-      schedules.data[i].quantity = 0;
+
+      if (vestQuantity == uint256(schedule.quantity)) {
+        schedules.data[i].quantity = 0;
+      } else {
+        schedules.data[i] = VestingSchedule({
+          startBlock: _blockNumber().toUint64(),
+          endBlock: schedule.endBlock,
+          quantity: uint256(schedule.quantity).sub(vestQuantity).toUint128()
+        });
+      }
     }
     require(totalVesting != 0, 'invalid vesting amount');
 
     accountEscrowedBalance[msg.sender][token] = accountEscrowedBalance[msg.sender][token].sub(
-      totalVesting.add(totalSlashing)
+      totalVesting
     );
     accountVestedBalance[msg.sender][token] = accountVestedBalance[msg.sender][token].add(
       totalVesting
     );
 
     token.safeTransfer(msg.sender, totalVesting);
-    if (totalSlashing != 0) _slash(token, totalSlashing);
 
-    emit Vested(token, msg.sender, _blockTimestamp(), totalVesting, totalSlashing);
+    emit Vested(token, msg.sender, _blockNumber(), totalVesting);
 
     return totalVesting;
   }
@@ -283,13 +278,13 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
     override
     view
     returns (
-      uint64 startTime,
-      uint64 endTime,
+      uint64 startBlock,
+      uint64 endBlock,
       uint128 quantity
     )
   {
     VestingSchedule memory schedule = accountVestingSchedules[account][token].data[index];
-    return (schedule.startTime, schedule.endTime, schedule.quantity);
+    return (schedule.startBlock, schedule.endBlock, schedule.quantity);
   }
 
   /**
@@ -322,39 +317,27 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
   /* ========== INTERNAL FUNCTIONS ========== */
 
   /**
-   * @dev if slashingTarget is equals to 0 address, burn the reward else transfer to the target
-   */
-  function _slash(IERC20Ext token, uint256 amount) internal {
-    address target = slashingTargets[token];
-    if (target != address(0)) {
-      token.safeTransfer(target, amount);
-    } else {
-      IERC20Burnable(address(token)).burn(amount);
-    }
-  }
-
-  /**
-   * @dev implements slashing mechanism
+   * @dev implements linear vesting mechanism
    * @dev this will allow user to claim token early, but slash the rest of token.
    */
   function _getVestingQuantity(
     uint256 quantity,
-    uint256 startTime,
-    uint256 endTime
+    uint256 startBlock,
+    uint256 endBlock
   ) internal view returns (uint256) {
-    if (_blockTimestamp() >= endTime) {
+    if (_blockNumber() >= endBlock) {
       return quantity;
     }
-    if (_blockTimestamp() <= startTime) {
+    if (_blockNumber() <= startBlock) {
       return 0;
     }
-    return (_blockTimestamp() - startTime).mul(quantity).div(endTime - startTime);
+    return (_blockNumber() - startBlock).mul(quantity).div(endBlock - startBlock);
   }
 
   /**
-   * @dev wrap timestamp so we can easily mock it
+   * @dev wrap block.number so we can easily mock it
    */
-  function _blockTimestamp() internal virtual view returns (uint256) {
-    return block.timestamp;
+  function _blockNumber() internal virtual view returns (uint256) {
+    return block.number;
   }
 }

--- a/contracts/liquidityMining/KyberRewardLocker.sol
+++ b/contracts/liquidityMining/KyberRewardLocker.sol
@@ -213,9 +213,6 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
     uint256 totalVesting = 0;
     for (uint256 i = 0; i < indexes.length; i++) {
       VestingSchedule memory schedule = schedules.data[indexes[i]];
-      if (schedule.quantity == 0) {
-        continue;
-      }
       uint256 vestQuantity = _getVestingQuantity(
         schedule.quantity,
         schedule.startBlock,
@@ -227,9 +224,9 @@ contract KyberRewardLocker is IKyberRewardLocker, PermissionAdmin {
       totalVesting = totalVesting.add(vestQuantity);
 
       if (vestQuantity == uint256(schedule.quantity)) {
-        schedules.data[i].quantity = 0;
+        schedules.data[indexes[i]].quantity = 0;
       } else {
-        schedules.data[i] = VestingSchedule({
+        schedules.data[indexes[i]] = VestingSchedule({
           startBlock: _blockNumber().toUint64(),
           endBlock: schedule.endBlock,
           quantity: uint256(schedule.quantity).sub(vestQuantity).toUint128()

--- a/contracts/mock/liquidityMining/MockRewardLocker.sol
+++ b/contracts/mock/liquidityMining/MockRewardLocker.sol
@@ -5,15 +5,15 @@ pragma abicoder v2;
 import {KyberRewardLocker} from '../../liquidityMining/KyberRewardLocker.sol';
 
 contract MockRewardLocker is KyberRewardLocker {
-  uint256 internal timestamp;
+  uint256 internal blockNumber;
 
   constructor(address _admin) KyberRewardLocker(_admin) {}
 
-  function setTimestamp(uint256 _timestamp) external {
-    timestamp = _timestamp;
+  function setBlockNumber(uint256 blockNumber_) external {
+    blockNumber = blockNumber_;
   }
 
-  function _blockTimestamp() internal override view returns (uint256) {
-    return timestamp;
+  function _blockNumber() internal override view returns (uint256) {
+    return blockNumber;
   }
 }

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -15,7 +15,6 @@ let rewardLocker;
 let rewardContract;
 let rewardContract2;
 let rewardToken;
-let slashingTarget;
 
 let txResult;
 
@@ -27,7 +26,6 @@ contract('KyberRewardLocker', (accounts) => {
     user2 = accounts[3];
     rewardContract = accounts[4];
     rewardContract2 = accounts[5];
-    slashingTarget = accounts[6];
 
     rewardToken = await KNC.new();
   });
@@ -71,17 +69,6 @@ contract('KyberRewardLocker', (accounts) => {
       expectEvent(txResult, 'SetVestingConfig', {lockDuration: new BN(1000)});
       Helper.assertEqual((await rewardLocker.vestingConfigPerToken(rewardToken.address)).lockDuration, new BN(1000));
     });
-
-    it('set slashing target', async () => {
-      await expectRevert(
-        rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: user1}),
-        'only admin'
-      );
-
-      txResult = await rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: admin});
-      expectEvent(txResult, 'SetSlashingTarget', {target: slashingTarget});
-      expect(await rewardLocker.slashingTargets(rewardToken.address)).equal(slashingTarget);
-    });
   });
 
   describe('lock and vest', async () => {
@@ -96,80 +83,47 @@ contract('KyberRewardLocker', (accounts) => {
       await rewardToken.transfer(rewardContract, vestingQuantity);
       await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
 
-      await rewardLocker.setTimestamp(new BN(7200));
+      await rewardLocker.setBlockNumber(new BN(7200));
 
       await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
 
       let vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
       expect(vestingSchedules.length).equals(1);
-      Helper.assertEqual(vestingSchedules[0].startTime, new BN(7200));
-      Helper.assertEqual(vestingSchedules[0].endTime, new BN(10800));
+      Helper.assertEqual(vestingSchedules[0].startBlock, new BN(7200));
+      Helper.assertEqual(vestingSchedules[0].endBlock, new BN(10800));
       Helper.assertEqual(vestingSchedules[0].quantity, vestingQuantity);
 
-      await rewardLocker.setTimestamp(new BN(10800));
+      await rewardLocker.setBlockNumber(new BN(10800));
 
       txResult = await rewardLocker.vestCompletedSchedules(rewardToken.address, {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
-        time: new BN(10800),
         vestedQuantity: vestingQuantity,
-        slashedQuantity: new BN(0),
       });
     });
 
-    it('lock and vest and burn with half time', async () => {
-      await rewardLocker.setSlashingTarget(rewardToken.address, Helper.zeroAddress, {from: admin});
-
+    it('lock and vest and claim with half time', async () => {
       let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
       await rewardToken.transfer(rewardContract, vestingQuantity);
       await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
 
-      await rewardLocker.setTimestamp(new BN(7200));
+      await rewardLocker.setBlockNumber(new BN(7200));
 
       await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
 
-      await rewardLocker.setTimestamp(new BN(9000));
+      await rewardLocker.setBlockNumber(new BN(9000));
 
       txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
-        time: new BN(9000),
         vestedQuantity: vestingQuantity.div(new BN(2)),
-        slashedQuantity: vestingQuantity.div(new BN(2)),
       });
 
       await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
-        to: Helper.zeroAddress,
-        value: vestingQuantity.div(new BN(2)),
-      });
-    });
-
-    it('lock and vest and transfer slashing quantity with half time', async () => {
-      await rewardLocker.setSlashingTarget(rewardToken.address, slashingTarget, {from: admin});
-
-      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
-      await rewardToken.transfer(rewardContract, vestingQuantity);
-      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
-
-      await rewardLocker.setTimestamp(new BN(7200));
-
-      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
-
-      await rewardLocker.setTimestamp(new BN(9000));
-
-      txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0)], {from: user1});
-      expectEvent(txResult, 'Vested', {
-        token: rewardToken.address,
-        beneficiary: user1,
-        time: new BN(9000),
-        vestedQuantity: vestingQuantity.div(new BN(2)),
-        slashedQuantity: vestingQuantity.div(new BN(2)),
-      });
-
-      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
-        to: slashingTarget,
+        from: rewardLocker.address,
+        to: user1,
         value: vestingQuantity.div(new BN(2)),
       });
     });

--- a/test/liquidityMining/rewardLocker.js
+++ b/test/liquidityMining/rewardLocker.js
@@ -4,6 +4,7 @@ const Helper = require('../helper.js');
 const expectEvent = require('@openzeppelin/test-helpers/src/expectEvent');
 const {expect} = require('chai');
 const BN = web3.utils.BN;
+const {precisionUnits} = require('../helper.js');
 
 const RewardLocker = artifacts.require('MockRewardLocker');
 const KNC = artifacts.require('KyberNetworkTokenV2');
@@ -61,87 +62,145 @@ contract('KyberRewardLocker', (accounts) => {
 
     it('set vesting config', async () => {
       await expectRevert(
-        rewardLocker.setVestingConfig(rewardToken.address, new BN(1000), new BN(10), {from: user1}),
+        rewardLocker.setVestingDuration(rewardToken.address, new BN(1000), {from: user1}),
         'only admin'
       );
 
-      txResult = await rewardLocker.setVestingConfig(rewardToken.address, new BN(1000), new BN(10), {from: admin});
-      expectEvent(txResult, 'SetVestingConfig', {lockDuration: new BN(1000)});
-      Helper.assertEqual((await rewardLocker.vestingConfigPerToken(rewardToken.address)).lockDuration, new BN(1000));
+      txResult = await rewardLocker.setVestingDuration(rewardToken.address, new BN(1000), {from: admin});
+      expectEvent(txResult, 'SetVestingDuration', {vestingDuration: new BN(1000)});
+      Helper.assertEqual(await rewardLocker.vestingDurationPerToken(rewardToken.address), new BN(1000));
     });
   });
 
   describe('lock and vest', async () => {
     beforeEach('setup', async () => {
       rewardLocker = await RewardLocker.new(admin);
-      await rewardLocker.addRewardsContract(rewardToken.address, rewardContract, {from: admin});
-      await rewardLocker.setVestingConfig(rewardToken.address, new BN(3600), new BN(60), {from: admin});
+      await rewardLocker.addRewardsContract(rewardToken.address, accounts[0], {from: admin});
+      await rewardLocker.setVestingDuration(rewardToken.address, new BN(3600), {from: admin});
+
+      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE);
     });
 
     it('lock and vest with full time', async () => {
-      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
-      await rewardToken.transfer(rewardContract, vestingQuantity);
-      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
-
       await rewardLocker.setBlockNumber(new BN(7200));
-
-      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+      await rewardLocker.lock(rewardToken.address, user1, precisionUnits.mul(new BN(7)));
 
       let vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
       expect(vestingSchedules.length).equals(1);
       Helper.assertEqual(vestingSchedules[0].startBlock, new BN(7200));
       Helper.assertEqual(vestingSchedules[0].endBlock, new BN(10800));
-      Helper.assertEqual(vestingSchedules[0].quantity, vestingQuantity);
+      Helper.assertEqual(vestingSchedules[0].quantity, precisionUnits.mul(new BN(7)));
 
       await rewardLocker.setBlockNumber(new BN(10800));
-
       txResult = await rewardLocker.vestCompletedSchedules(rewardToken.address, {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
-        vestedQuantity: vestingQuantity,
+        vestedQuantity: precisionUnits.mul(new BN(7)),
+        index: new BN(0),
       });
     });
 
     it('lock and vest and claim with half time', async () => {
-      let vestingQuantity = new BN(10).pow(new BN(18)).mul(new BN(7));
-      await rewardToken.transfer(rewardContract, vestingQuantity.mul(new BN(2)));
-      await rewardToken.approve(rewardLocker.address, Helper.MAX_ALLOWANCE, {from: rewardContract});
-
       await rewardLocker.setBlockNumber(new BN(7200));
-
-      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+      await rewardLocker.lock(rewardToken.address, user1, precisionUnits.mul(new BN(7)));
 
       await rewardLocker.setBlockNumber(new BN(9000));
-
-      await rewardLocker.lock(rewardToken.address, user1, vestingQuantity, {from: rewardContract});
+      await rewardLocker.lock(rewardToken.address, user1, precisionUnits.mul(new BN(8)));
 
       await rewardLocker.setBlockNumber(new BN(10800));
-
       txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0), new BN(1)], {from: user1});
       expectEvent(txResult, 'Vested', {
         token: rewardToken.address,
         beneficiary: user1,
-        vestedQuantity: vestingQuantity.mul(new BN(3)).div(new BN(2)),
+        vestedQuantity: precisionUnits.mul(new BN(7)),
+        index: new BN(0),
       });
-
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        vestedQuantity: precisionUnits.mul(new BN(4)),
+        index: new BN(1),
+      });
       await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
         from: rewardLocker.address,
         to: user1,
-        value: vestingQuantity.mul(new BN(3)).div(new BN(2)),
+        value: precisionUnits.mul(new BN(11)),
       });
-
-      Helper.assertEqual(await rewardLocker.numVestingSchedules(user1, rewardToken.address), new BN(2));
 
       let vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
       expect(vestingSchedules.length).equals(2);
-      Helper.assertEqual(vestingSchedules[0].startBlock, new BN(7200));
-      Helper.assertEqual(vestingSchedules[0].endBlock, new BN(10800));
-      Helper.assertEqual(vestingSchedules[0].quantity, new BN(0));
+      Helper.assertEqual(vestingSchedules[0].vestedQuantity, precisionUnits.mul(new BN(7)));
+      Helper.assertEqual(vestingSchedules[1].vestedQuantity, precisionUnits.mul(new BN(4)));
 
-      Helper.assertEqual(vestingSchedules[1].startBlock, new BN(10800));
-      Helper.assertEqual(vestingSchedules[1].endBlock, new BN(12600));
-      Helper.assertEqual(vestingSchedules[1].quantity, vestingQuantity.div(new BN(2)));
+      await rewardLocker.setBlockNumber(new BN(11700));
+      txResult = await rewardLocker.vestScheduleAtIndex(rewardToken.address, [new BN(0), new BN(1)], {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        vestedQuantity: precisionUnits.mul(new BN(2)),
+        index: new BN(1),
+      });
+      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
+        from: rewardLocker.address,
+        to: user1,
+        value: precisionUnits.mul(new BN(2)),
+      });
+      vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
+      expect(vestingSchedules.length).equals(2);
+      Helper.assertEqual(vestingSchedules[0].vestedQuantity, precisionUnits.mul(new BN(7)));
+      Helper.assertEqual(vestingSchedules[1].vestedQuantity, precisionUnits.mul(new BN(6)));
+    });
+
+    it('#vestSchedulesInRange', async () => {
+      await rewardLocker.setBlockNumber(new BN(7200));
+      await rewardLocker.lock(rewardToken.address, user1, precisionUnits.mul(new BN(7)));
+
+      await rewardLocker.setBlockNumber(new BN(9000));
+      await rewardLocker.lock(rewardToken.address, user1, precisionUnits.mul(new BN(8)));
+
+      await rewardLocker.setBlockNumber(new BN(10800));
+      txResult = await rewardLocker.vestSchedulesInRange(rewardToken.address, new BN(0), new BN(1), {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        vestedQuantity: precisionUnits.mul(new BN(7)),
+        index: new BN(0),
+      });
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        vestedQuantity: precisionUnits.mul(new BN(4)),
+        index: new BN(1),
+      });
+      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
+        from: rewardLocker.address,
+        to: user1,
+        value: precisionUnits.mul(new BN(11)),
+      });
+
+      let vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
+      expect(vestingSchedules.length).equals(2);
+      Helper.assertEqual(vestingSchedules[0].vestedQuantity, precisionUnits.mul(new BN(7)));
+      Helper.assertEqual(vestingSchedules[1].vestedQuantity, precisionUnits.mul(new BN(4)));
+
+      await rewardLocker.setBlockNumber(new BN(11700));
+      txResult = await rewardLocker.vestSchedulesInRange(rewardToken.address, new BN(0), new BN(1), {from: user1});
+      expectEvent(txResult, 'Vested', {
+        token: rewardToken.address,
+        beneficiary: user1,
+        vestedQuantity: precisionUnits.mul(new BN(2)),
+        index: new BN(1),
+      });
+      await expectEvent.inTransaction(txResult.tx, rewardToken, 'Transfer', {
+        from: rewardLocker.address,
+        to: user1,
+        value: precisionUnits.mul(new BN(2)),
+      });
+      vestingSchedules = await rewardLocker.getVestingSchedules(user1, rewardToken.address);
+      expect(vestingSchedules.length).equals(2);
+      Helper.assertEqual(vestingSchedules[0].vestedQuantity, precisionUnits.mul(new BN(7)));
+      Helper.assertEqual(vestingSchedules[1].vestedQuantity, precisionUnits.mul(new BN(6)));
     });
   });
 });


### PR DESCRIPTION
- change from slashing the remaining reward to linear vesting
- mechanism:
   - user has a vesting schedule from block 20 to 25  with 100 knc
   - user call vest at block 23
   - user receive 60 knc. 
   - startTime is now updated to 23
   - amount is updated to 40 knc